### PR TITLE
feat: docker-compose에 nginx와 certbot 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ app_setup.sh
 
 ### etc ###
 .DS_Store
+/logs
+/data/certbot/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM amazoncorretto:17
 
 ARG JAR_FILE=build/libs/*.jar
-
 COPY ${JAR_FILE} app.jar
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ARG SERVER_PROFILE
+ENV SERVER_PROFILE=$SERVER_PROFILE
+
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=${SERVER_PROFILE}", "app.jar"]

--- a/Makefile
+++ b/Makefile
@@ -6,29 +6,23 @@ default = "\033[0m"
 all:
 
 # app 컨테이너 생성 후, 실행
-.PHONY: app
-app:
-	@echo $(green)Executed: docker compose up -d app $(default)
-	@docker compose up -d app
+.PHONY: up
+up:
+	@echo $(green)Executed: docker compose up -d ${container} $(default)
+	@docker compose up -d ${container}
 
-# db 컨테이너 생성 후, 실행
-.PHONY: mysql_db
-mysql_db:
-	@echo $(green)Executed: docker compose up -d mysql_db $(default)
-	@docker compose up -d mysql_db
+# docker-compose.yml를 통해 생성된 container, network, volume 제거
+.PHONY: down
+down:
+	@echo $(green)Executed: docker compose down ${container} $(default)
+	@docker compose down ${container}
 
-## docker-compose.yml를 통해 생성된 container, network, volume 제거
-#.PHONY: down
-#down:
-#	@echo $(green)Executed: docker compose down $(default)
-#	@docker compose down
-
-## docker-compose.yml를 통해 생성된 container, network, volume, image 제거
-## --rmi all: down 시, 생성된 이미지 제거
-#.PHONY: clean
-#clean:
-#	@echo $(green)Executed: docker compose down --rmi all $(default)
-#	@docker compose down --rmi all
+# docker-compose.yml를 통해 생성된 container, network, volume, image 제거
+# --rmi all: down 시, 생성된 이미지 제거
+.PHONY: clean
+clean:
+	@echo $(green)Executed: docker compose down ${container} --rmi all $(default)
+	@docker compose down ${container} --rmi all
 
 ## docker-compose.yml를 통해 생성된 container, network, image, 모든 익명 volume 제거
 ## prun -f: 모든 익명 볼륨 제거

--- a/data/nginx/conf.d/app.conf
+++ b/data/nginx/conf.d/app.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name mongji.site www.mongji.site;
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+upstream docker-app {
+	server app:8080;
+}
+
+server {
+    listen 443 ssl;
+    server_name mongji.site www.mongji.site;
+    server_tokens off;
+
+    ssl_certificate /etc/letsencrypt/live/mongji.site/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mongji.site/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+            proxy_pass  http://docker-app;
+            proxy_set_header    Host                $http_host;
+            proxy_set_header    X-Real-IP           $remote_addr;
+            proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,22 +2,51 @@ services:
   mysql_db:
     container_name: mysql_db
     image: mysql
-    volumes:
-      - db_data:/var/lib/mysql
+    restart: always
+    platform: linux/x86_64
     ports:
       - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       TZ: "Asia/Seoul"
-    platform: linux/x86_64
-    restart: always
 
   app:
     container_name: app
     image: ${DOCKER_USERNAME}/${DOCKER_REPOSITORY}
     ports:
       - "8080:8080"
+    environment:
+      TZ: "Asia/Seoul"
+
+  nginx:
+    container_name: nginx
+    image: nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./data/nginx/conf.d:/etc/nginx/conf.d
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+    environment:
+      TZ: "Asia/Seoul"
+
+  certbot:
+    container_name: certbot
+    image: certbot/certbot
+    restart: unless-stopped
+    volumes:
+      - ./logs/letsencrypt:/var/log/letsencrypt
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    environment:
+      TZ: "Asia/Seoul"
 
 volumes:
   db_data:

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+  echo 'Error: docker-compose is not installed.' >&2
+  exit 1
+fi
+
+domains="mongji.site"
+rsa_key_size=4096
+data_path="./data/certbot"
+email="thseogh135@gmail.com" # Adding a valid address is strongly recommended
+staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose exec nginx nginx -s reload


### PR DESCRIPTION
## Related Issue 🚀
- #16

## Work Description ✏️
- docker-compose에 nginx, certbot 구성
- init-letsencrypt.sh를 사용해 더미 인증서 발급
  - nginx를 실행시키기 위함
- letsencrypt + certbot을 이용해 ssl 설정
- http(80)으로 요청 시, https(443)으로 리다이렉트


## PR Point 📸
- 도메인 SSL 인증서가 제대로 적용되는지?